### PR TITLE
[feat] 로그인 기능 구현, 로그인 여부에 따른 리다이렉트 처리 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,10 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import {
+    BrowserRouter as Router,
+    Route,
+    Routes,
+    Navigate,
+} from "react-router-dom";
+import { useEffect, useState } from "react";
 
 // page
 import Signin from "./pages/Signin";
@@ -6,13 +12,52 @@ import Signup from "./pages/Signup";
 import Todo from "./pages/Todo";
 
 export default function App() {
+    // 로그인 여부 상태
+    const [isLogin, setIsLogin] = useState(false);
+
+    // 로그인 여부 판별
+    useEffect(() => {
+        if (window.localStorage.getItem("loginToken")) {
+            setIsLogin(true);
+        } else {
+            setIsLogin(false);
+        }
+    }, []);
+
     return (
         <div>
             <Router>
                 <Routes>
-                    <Route path="/signin" element={<Signin />} />
-                    <Route path="/signup" element={<Signup />} />
-                    <Route path="/todo" element={<Todo />} />
+                    <Route
+                        path="/signin"
+                        element={
+                            isLogin ? (
+                                <Navigate replace to={"/todo"} />
+                            ) : (
+                                <Signin />
+                            )
+                        }
+                    />
+                    <Route
+                        path="/signup"
+                        element={
+                            isLogin ? (
+                                <Navigate replace to={"/todo"} />
+                            ) : (
+                                <Signup />
+                            )
+                        }
+                    />
+                    <Route
+                        path="/todo"
+                        element={
+                            isLogin ? (
+                                <Todo />
+                            ) : (
+                                <Navigate replace to={"/signin"} />
+                            )
+                        }
+                    />
                 </Routes>
             </Router>
         </div>

--- a/src/pages/Signin.js
+++ b/src/pages/Signin.js
@@ -1,3 +1,75 @@
+import { useState, useEffect } from "react";
+
 export default function Signin() {
-    return <div>signIn</div>;
+    // 이메일, 비밀번호
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+
+    // 유효성 검사 관련 상태
+    const [validationEmail, setValidationEmail] = useState(false);
+    const [validationPW, setValidationPW] = useState(false);
+
+    // 이메일 입력
+    const handleInputEmail = (event) => {
+        const inputEmail = event.target.value;
+        setEmail(inputEmail);
+    };
+
+    // 비밀번호 입력
+    const handleInputPW = (event) => {
+        const inputPassword = event.target.value;
+        setPassword(inputPassword);
+    };
+
+    // 유효성 검사에 따른 버튼 disabled 조건 변경
+    useEffect(() => {
+        if (email.includes("@")) {
+            setValidationEmail(true);
+        } else {
+            setValidationEmail(false);
+        }
+
+        if (password.length >= 8) {
+            setValidationPW(true);
+        } else {
+            setValidationPW(false);
+        }
+    }, [email, password]);
+
+    // 로그인
+    const handleSubmit = (event) => {
+        event.preventDefault();
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <div>
+                <div id="email">
+                    <label htmlFor="email">이메일</label>
+                    <input
+                        data-testid="email-input"
+                        type="email"
+                        placeholder="이메일을 입력해주세요."
+                        onChange={handleInputEmail}
+                    />
+                </div>
+                <div id="password">
+                    <label>비밀번호</label>
+                    <input
+                        data-testid="password-input"
+                        type="password"
+                        placeholder="비밀번호를 8자 이상 입력해주세요."
+                        onChange={handleInputPW}
+                    />
+                </div>
+                <button
+                    data-testid="signup-button"
+                    type="submit"
+                    disabled={!(validationEmail && validationPW)}
+                >
+                    로그인
+                </button>
+            </div>
+        </form>
+    );
 }

--- a/src/pages/Signin.js
+++ b/src/pages/Signin.js
@@ -50,6 +50,10 @@ export default function Signin() {
             .post(`${url}/auth/signin`, loginData)
             .then((res) => {
                 localStorage.setItem("loginToken", res.data.access_token);
+                alert(
+                    "로그인에 성공하셨습니다.\nToDo List 페이지로 이동합니다."
+                );
+                window.location.reload();
             })
             .catch((error) => alert(error.response.data.message));
     };

--- a/src/pages/Signin.js
+++ b/src/pages/Signin.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import axios from "axios";
 
 export default function Signin() {
     // 이메일, 비밀번호
@@ -8,6 +9,9 @@ export default function Signin() {
     // 유효성 검사 관련 상태
     const [validationEmail, setValidationEmail] = useState(false);
     const [validationPW, setValidationPW] = useState(false);
+
+    // API
+    const url = "https://www.pre-onboarding-selection-task.shop";
 
     // 이메일 입력
     const handleInputEmail = (event) => {
@@ -39,6 +43,15 @@ export default function Signin() {
     // 로그인
     const handleSubmit = (event) => {
         event.preventDefault();
+
+        const loginData = { email, password };
+
+        axios
+            .post(`${url}/auth/signin`, loginData)
+            .then((res) => {
+                localStorage.setItem("loginToken", res.data.access_token);
+            })
+            .catch((error) => alert(error.response.data.message));
     };
 
     return (


### PR DESCRIPTION
## 개요
로그인 기능 완료
로그인 여부에 따른 리다이렉트 처리 완료
## 작업사항
- 이메일, 비밀번호 유효성 검사 기능 구현
  - 이메일 조건: @ 포함
  - 비밀번호 조건: 8자 이상
- 유효성 검사 통과되지 않을 경우 button에 disabled 속성 부여
- axios를 사용해 로그인 API 연동
- 로그인 성공 시 응답받은 JWT 로컬 스토리지에 저장
- 로그인 성공 시 투두리스트 페이지 경로로 이동
- 로그인 여부에 따른 경로 처리
  - 로컬 스토리지에 토큰이 있는 상태로 로그인, 회원가입 페이지 접속 시 투두 리스트 페이지 경로로 리다이렉트
  - 로컬 스토리지에 토큰이 없는 상태로 투두 리스트 페이지 접속 시 로그인 페이지 경로로 리다이렉트
## 개선점
로그인 컴포넌트(`Signin`)에서 axios로 로그인 처리 후 `useNavigate`를 활용한 `navigate(”/todo”)`가 먹히지 않아서 새로고침으로 해결했습니다.

`App.js`에서 `isLogin` 상태가 `false`인 상태에서 → `Signin` 컴포넌트로 들어와서 로그인을 진행한 후 `“/todo”` 경로로 이동하려는데 → `App.js`에서 `isLogin` 상태가 `false`이므로 `“/todo”` 경로 라우트를 `Signin` 컴포넌트로 가게 해서 생긴 문제인 듯 합니다. 다른 기능 구현 완료 후 개선 예정입니다.